### PR TITLE
[Bugfix] parse error locations by Aqua and others

### DIFF
--- a/src/xml.jl
+++ b/src/xml.jl
@@ -9,8 +9,18 @@ Get the filename, relative path and line number of the failing test evaluation
 """
 function get_test_location(message::String, pkgname::String)
     tmp = split(split(message, "\n")[1], "/")
-    ind = findall(x -> x == pkgname, tmp)[1]
-    return join(tmp[(ind + 2):end], '/')
+    found = findall(x -> x == pkgname, tmp)
+    if isempty(found)
+        @warn "DownstreamTester: Error location outside of actual package, looking for alternatives"
+        found = findall(x -> x == "Aqua", tmp)
+        if isempty(found)
+            @info "Unknown package, returning full path"
+            return join(tmp, '/')
+        end
+        @info "DownstreamTester: it was Aqua"
+        return "AQUA/" * join(tmp[(found[1] + 2):end], '/')
+    end
+    return join(tmp[(found[1] + 2):end], '/')
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ println("Testing...")
 
 include("test_previous_day.jl")
 #include("test_infos.jl")
+include("test_xml.jl")
 
 @testset "ExplicitImports" begin
     @test ExplicitImports.check_no_implicit_imports(DownstreamTester) === nothing
@@ -15,7 +16,6 @@ end
 
 @testset "Aqua" begin
     Aqua.test_all(DownstreamTester)
-
 end
 
 if isdefined(Docs, :undocumented_names) # >=1.11

--- a/test/test_xml.jl
+++ b/test/test_xml.jl
@@ -1,0 +1,30 @@
+using DownstreamTester: get_test_location
+
+@testset "get_test_location" begin
+
+    # Working state
+    @test get_test_location(
+        "Test Failed at /home/runner/.julia/packages/ExtendableGrids/nOn1T/test/runtests.jl:484\n" *
+            "Expression: sha_code == \"9596c59f6b0870dd4a42a7a48725c2257f260757e15cc5ac433e5e8e235659d9\"" *
+            "Evaluated: \"28a786f7c929dd592eb428d95cb1dcd77e92bd2dce696613ac26440d44597aea\" == \"9596c59f6b0870dd4a42a7a48725c2257f260757e15cc5ac433e5e8e235659d9\"",
+        "ExtendableGrids"
+    ) == "test/runtests.jl:484"
+
+    # Aqua treatment
+
+    @test get_test_location(
+        "Aqua: Test Failed at /home/runner/.julia/packages/Aqua/epbUr/src/persistent_tasks.jl:38\n" *
+            "Expression: !(has_persistent_tasks(package; kwargs...))" *
+            "Evaluated: !(has_persistent_tasks(Base.PkgId(Base.UUID(\"82b139dc-5afc-11e9-35da-9b9bdfd336f3\"), \"VoronoiFVM\")))",
+        "VoronoiFVM"
+    ) == "AQUA/src/persistent_tasks.jl:38"
+
+    # Other package location
+    @test get_test_location(
+        "Test Failed at /home/runner/.julia/packages/ExtendableGrids/nOn1T/test/runtests.jl:484\n" *
+            "Expression: sha_code == \"9596c59f6b0870dd4a42a7a48725c2257f260757e15cc5ac433e5e8e235659d9\"" *
+            "Evaluated: \"28a786f7c929dd592eb428d95cb1dcd77e92bd2dce696613ac26440d44597aea\" == \"9596c59f6b0870dd4a42a7a48725c2257f260757e15cc5ac433e5e8e235659d9\"",
+        "VoronoiFVM"
+    ) == "Test Failed at /home/runner/.julia/packages/ExtendableGrids/nOn1T/test/runtests.jl:484"
+
+end


### PR DESCRIPTION
Aqua tests don't fail within the package e.g. `/home/runner/.julia/packages/YourPackage/src/buggy.jl:42`
but within Aqua itself, e.g. `/home/runner/.julia/packages/Aqua/src/persistent_tasks.jl:42`

This lead to DownstreamTester erroring out trying to shorten the error location.

This PR adds a fix which checks if `YourPackage` actually was part of the full path.
If that isn't the case it will first check for `Aqua` 
and  if that also fails it will give up and return the full first line of the error message instead.

This also adds tests for the expected behaviour for all three cases.